### PR TITLE
feat: add hierarchy API schemas and documentation

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,62 @@
+target-version = "py312"
+line-length = 88
+
+[lint]
+select = [
+    "F",      # Pyflakes - catches logic errors
+    "E", "W", # pycodestyle - PEP 8 style checking
+    "I",      # isort - import sorting
+    "B",      # flake8-bugbear - common gotchas
+    "UP",     # pyupgrade - modern Python syntax
+    "SIM",    # flake8-simplify - suggests simpler logic
+    "PL",     # Pylint - comprehensive code quality
+    "ANN",    # flake8-annotations - type hints (ANN401 bans Any)
+    "RUF",    # Ruff-specific rules
+    "PERF",   # Perflint - performance anti-patterns
+    "BLE",    # flake8-blind-except - exception handling
+    "FA",     # flake8-future-annotations
+    "TRY",    # tryceratops - clean exception handling
+    "RSE",    # flake8-raise - raise statement best practices
+    "C4",     # flake8-comprehensions - better comprehensions
+    "C90",    # mccabe - cyclomatic complexity
+    "S",      # flake8-bandit - security checks
+    "PT",     # flake8-pytest-style - pytest best practices
+    "DTZ",    # flake8-datetimez - timezone-aware datetime
+    "PIE",    # flake8-pie - misc code improvements
+    "RET",    # flake8-return - return statement improvements
+    "PTH",    # flake8-use-pathlib - prefer pathlib over os.path
+    "TCH",    # flake8-type-checking - TYPE_CHECKING optimization
+    "LOG",    # flake8-logging - logging best practices
+    "PGH",    # pygrep-hooks - ban blanket type: ignore (PGH003)
+]
+
+ignore = [
+    "E501",    # Line length (handled by formatter)
+    "COM812",  # Trailing comma (conflicts with formatter)
+    "ISC001",  # Implicit string concatenation (conflicts with formatter)
+    "PLR0913", # Too many arguments - sometimes necessary
+    "PLR2004", # Magic value comparison - sometimes reasonable
+    "TRY003",  # Long exception message - custom error messages are common
+]
+
+[lint.mccabe]
+max-complexity = 10
+
+[lint.pylint]
+max-args = 6
+max-branches = 12
+
+[lint.isort]
+force-single-line = false
+lines-after-imports = 2
+known-first-party = ["lsap"]
+
+[lint.per-file-ignores]
+"tests/**/*.py" = ["ANN", "S101", "PLR2004"]
+"**/test_*.py" = ["ANN", "S101", "PLR2004"]
+"conftest.py" = ["ANN"]
+"__init__.py" = ["F401"]  # Allow unused imports for re-export
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/src/lsap/schema/draft/hierarchy.py
+++ b/src/lsap/schema/draft/hierarchy.py
@@ -1,18 +1,15 @@
 from pathlib import Path
-from typing import Annotated, Final, Literal, Union
+from typing import Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from lsap.schema.abc import Response
-from lsap.schema.locate import LocateRequest, Position
+from lsap.schema.locate import LocateRequest
+from lsap.schema.models import Position
 
 
 class HierarchyNode(BaseModel):
-    """
-    Represents a node in a hierarchy graph.
-
-    Applicable to any hierarchical relationship: function calls, type inheritance, etc.
-    """
+    """Represents a symbol node in a hierarchy graph."""
 
     id: str
     name: str
@@ -23,204 +20,242 @@ class HierarchyNode(BaseModel):
 
 
 class HierarchyItem(BaseModel):
-    """
-    Represents an item in a flattened hierarchy tree for rendering.
-
-    Applicable to any hierarchical relationship.
-    """
+    """A node in the flattened hierarchy tree with its path from root."""
 
     name: str
     kind: str
     file_path: Path
     level: int
+    """Depth level (1 = direct caller/callee of root)"""
+    chain: list[str]
+    """Full path from this node to root, e.g. ["caller", "root"]"""
     detail: str | None = None
     is_cycle: bool = False
 
 
-class CallEdgeMetadata(BaseModel):
-    """Metadata specific to call relationships"""
-
-    call_sites: list[Position]
-    """Positions where the call occurs"""
+# =============================================================================
+# Call Hierarchy
+# =============================================================================
 
 
-class TypeEdgeMetadata(BaseModel):
-    """Metadata specific to type inheritance relationships"""
+class CallSite(BaseModel):
+    """A specific location where a call occurs."""
 
-    relationship: Literal["extends", "implements"]
-    """Type of inheritance relationship"""
+    position: Position
+    snippet: str | None = None
 
 
-class HierarchyEdge(BaseModel):
-    """
-    Represents a directed edge in the hierarchy graph.
-
-    The edge connects two nodes and may carry metadata specific to the relationship type.
-    """
+class CallHierarchyEdge(BaseModel):
+    """An edge in the call hierarchy graph."""
 
     from_node_id: str
     to_node_id: str
-    metadata: (
-        Annotated[
-            Union[CallEdgeMetadata, TypeEdgeMetadata],
-            Field(
-                discriminator="relationship"
-                if hasattr(TypeEdgeMetadata, "relationship")
-                else None
-            ),
-        ]
-        | None
-    ) = None
+    call_sites: list[CallSite] = Field(default_factory=list)
 
 
-class HierarchyRequest(LocateRequest):
+class CallHierarchyRequest(LocateRequest):
     """
-    Traces hierarchical relationships in a directed graph of symbols.
+    Traces function/method call relationships.
 
-    This API traces two types of hierarchies:
-    - "call": Function/method call relationships (who calls whom)
-    - "type": Class/interface inheritance relationships (parent-child)
-
-    Usage Examples:
-
-    1. Find who calls a function (incoming calls):
-       HierarchyRequest(
-           hierarchy_type="call",
-           locate=Locate(file_path="src/main.py", scope=LineScope(line=10), find="process_data"),
-           direction="incoming",
-           depth=2
-       )
-
-    2. Find what a function calls (outgoing calls):
-       HierarchyRequest(
-           hierarchy_type="call",
-           locate=Locate(file_path="src/main.py", scope=LineScope(line=10), find="process_data"),
-           direction="outgoing",
-           depth=2
-       )
-
-    3. Find parent classes (incoming in type hierarchy):
-       HierarchyRequest(
-           hierarchy_type="type",
-           locate=Locate(file_path="src/models.py", scope=LineScope(line=5), find="UserModel"),
-           direction="incoming",
-           depth=2
-       )
-
-    4. Find child classes (outgoing in type hierarchy):
-       HierarchyRequest(
-           hierarchy_type="type",
-           locate=Locate(file_path="src/models.py", scope=LineScope(line=5), find="BaseModel"),
-           direction="outgoing",
-           depth=2
-       )
-
-    Direction is in graph terms (not hierarchy-specific):
-    - "incoming": predecessors (callers for calls, parent classes for types)
-    - "outgoing": successors (callees for calls, child classes for types)
-    - "both": explore both directions
+    Direction:
+    - "incoming": Find callers (who calls this?)
+    - "outgoing": Find callees (what does this call?)
+    - "both": Both directions
     """
-
-    hierarchy_type: Literal["call", "type"]
-    """Type of hierarchical relationship to trace"""
 
     direction: Literal["incoming", "outgoing", "both"] = "both"
-    """Graph traversal direction"""
-
     depth: int = 2
-    """Maximum traversal depth"""
-
     include_external: bool = False
-    """Whether to include external references (applicable to certain hierarchy types)"""
 
 
-markdown_template: Final = """
-# {{ root.name }} Hierarchy ({{ hierarchy_type }}, depth: {{ depth }})
+call_hierarchy_template: Final = """\
+# Call Hierarchy: `{{ root.name }}`
 
-{% if direction == "incoming" or direction == "both" %}
-## Incoming
+Root: `{{ root.name }}` (`{{ root.kind }}`) at `{{ root.file_path }}`
+{%- if root.detail %}
+Detail: {{ root.detail }}
+{%- endif %}
 
-{% for item in items_incoming %}
-{% for i in (1..item.level) %}#{% endfor %}## {{ item.name }}
+{% if direction == "incoming" or direction == "both" -%}
+## Callers (incoming)
+
+{% if items_incoming.size == 0 -%}
+No callers found.
+{% else -%}
+{% for item in items_incoming -%}
+{% for i in (1..item.level) %}#{% endfor %}## `{{ item.name }}`
+{{ item.chain | join: " -> " }}
 - Kind: `{{ item.kind }}`
 - File: `{{ item.file_path }}`
-{%- if item.detail != nil %}
+{%- if item.detail %}
 - Detail: {{ item.detail }}
 {%- endif %}
 {%- if item.is_cycle %}
-- ⚠️ Cycle detected
+- (cycle detected)
 {%- endif %}
 
-{% endfor %}
+{% endfor -%}
 {% endif %}
+{% endif -%}
 
-{% if direction == "outgoing" or direction == "both" %}
-## Outgoing
+{% if direction == "outgoing" or direction == "both" -%}
+## Callees (outgoing)
 
-{% for item in items_outgoing %}
-{% for i in (1..item.level) %}#{% endfor %}## {{ item.name }}
+{% if items_outgoing.size == 0 -%}
+No callees found.
+{% else -%}
+{% for item in items_outgoing -%}
+{% for i in (1..item.level) %}#{% endfor %}## `{{ item.name }}`
+{{ item.chain | join: " -> " }}
 - Kind: `{{ item.kind }}`
 - File: `{{ item.file_path }}`
-{%- if item.detail != nil %}
+{%- if item.detail %}
 - Detail: {{ item.detail }}
 {%- endif %}
 {%- if item.is_cycle %}
-- ⚠️ Cycle detected
+- (cycle detected)
 {%- endif %}
 
-{% endfor %}
+{% endfor -%}
 {% endif %}
+{% endif -%}
 """
 
 
-class HierarchyResponse(Response):
-    """
-    Response containing the hierarchy graph and flattened tree.
-
-    The response uses generic graph terminology:
-    - edges_incoming: edges pointing to nodes (callers or supertypes)
-    - edges_outgoing: edges pointing from nodes (callees or subtypes)
-    - items_incoming: flattened list of incoming relationships
-    - items_outgoing: flattened list of outgoing relationships
-    """
-
-    hierarchy_type: Literal["call", "type"]
-    """Type of hierarchical relationship"""
+class CallHierarchyResponse(Response):
+    """Response containing the call hierarchy."""
 
     root: HierarchyNode
-    """The starting node"""
-
     nodes: dict[str, HierarchyNode]
-    """All nodes in the hierarchy graph"""
-
-    edges_incoming: dict[str, list[HierarchyEdge]]
-    """Incoming edges for each node (predecessors in the graph)"""
-
-    edges_outgoing: dict[str, list[HierarchyEdge]]
-    """Outgoing edges for each node (successors in the graph)"""
-
-    items_incoming: list[HierarchyItem] = []
-    """Flattened list of incoming relationships for tree rendering"""
-
-    items_outgoing: list[HierarchyItem] = []
-    """Flattened list of outgoing relationships for tree rendering"""
-
-    direction: str
+    edges_incoming: dict[str, list[CallHierarchyEdge]]
+    edges_outgoing: dict[str, list[CallHierarchyEdge]]
+    items_incoming: list[HierarchyItem] = Field(default_factory=list)
+    items_outgoing: list[HierarchyItem] = Field(default_factory=list)
+    direction: Literal["incoming", "outgoing", "both"]
     depth: int
 
     model_config = ConfigDict(
         json_schema_extra={
-            "markdown": markdown_template,
+            "markdown": call_hierarchy_template,
+        }
+    )
+
+
+# =============================================================================
+# Type Hierarchy
+# =============================================================================
+
+
+class TypeRelation(BaseModel):
+    """Describes the inheritance relationship type."""
+
+    kind: Literal["extends", "implements"]
+
+
+class TypeHierarchyEdge(BaseModel):
+    """An edge in the type hierarchy graph."""
+
+    from_node_id: str
+    to_node_id: str
+    relation: TypeRelation
+
+
+class TypeHierarchyRequest(LocateRequest):
+    """
+    Traces class/interface inheritance relationships.
+
+    Direction:
+    - "supertypes": Find parent classes (what does this inherit?)
+    - "subtypes": Find child classes (what inherits from this?)
+    - "both": Both directions
+    """
+
+    direction: Literal["supertypes", "subtypes", "both"] = "both"
+    depth: int = 2
+
+
+type_hierarchy_template: Final = """\
+# Type Hierarchy: `{{ root.name }}`
+
+Root: `{{ root.name }}` (`{{ root.kind }}`) at `{{ root.file_path }}`
+{%- if root.detail %}
+Detail: {{ root.detail }}
+{%- endif %}
+
+{% if direction == "supertypes" or direction == "both" -%}
+## Supertypes (parents)
+
+{% if items_supertypes.size == 0 -%}
+No supertypes found.
+{% else -%}
+{% for item in items_supertypes -%}
+{% for i in (1..item.level) %}#{% endfor %}## `{{ item.name }}`
+{{ item.chain | join: " <- " }}
+- Kind: `{{ item.kind }}`
+- File: `{{ item.file_path }}`
+{%- if item.detail %}
+- Detail: {{ item.detail }}
+{%- endif %}
+{%- if item.is_cycle %}
+- (cycle detected)
+{%- endif %}
+
+{% endfor -%}
+{% endif %}
+{% endif -%}
+
+{% if direction == "subtypes" or direction == "both" -%}
+## Subtypes (children)
+
+{% if items_subtypes.size == 0 -%}
+No subtypes found.
+{% else -%}
+{% for item in items_subtypes -%}
+{% for i in (1..item.level) %}#{% endfor %}## `{{ item.name }}`
+{{ item.chain | join: " -> " }}
+- Kind: `{{ item.kind }}`
+- File: `{{ item.file_path }}`
+{%- if item.detail %}
+- Detail: {{ item.detail }}
+{%- endif %}
+{%- if item.is_cycle %}
+- (cycle detected)
+{%- endif %}
+
+{% endfor -%}
+{% endif %}
+{% endif -%}
+"""
+
+
+class TypeHierarchyResponse(Response):
+    """Response containing the type hierarchy."""
+
+    root: HierarchyNode
+    nodes: dict[str, HierarchyNode]
+    edges_supertypes: dict[str, list[TypeHierarchyEdge]]
+    edges_subtypes: dict[str, list[TypeHierarchyEdge]]
+    items_supertypes: list[HierarchyItem] = Field(default_factory=list)
+    items_subtypes: list[HierarchyItem] = Field(default_factory=list)
+    direction: Literal["supertypes", "subtypes", "both"]
+    depth: int
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "markdown": type_hierarchy_template,
         }
     )
 
 
 __all__ = [
-    "HierarchyNode",
+    "CallHierarchyEdge",
+    "CallHierarchyRequest",
+    "CallHierarchyResponse",
+    "CallSite",
     "HierarchyItem",
-    "HierarchyEdge",
-    "CallEdgeMetadata",
-    "TypeEdgeMetadata",
-    "HierarchyRequest",
-    "HierarchyResponse",
+    "HierarchyNode",
+    "TypeHierarchyEdge",
+    "TypeHierarchyRequest",
+    "TypeHierarchyResponse",
+    "TypeRelation",
 ]


### PR DESCRIPTION
## Summary
- Added Call Hierarchy and Type Hierarchy schemas in `src/lsap/schema/draft/hierarchy.py`.
- Added documentation for Hierarchy APIs in `docs/schemas/draft/hierarchy.md`.
- Added `ruff.toml` for project linting configuration.