### PR TITLE
feat: trim empty lines from code snippets in reference context

### DIFF
--- a/src/lsap/capability/reference.py
+++ b/src/lsap/capability/reference.py
@@ -97,12 +97,13 @@ class ReferenceCapability(Capability[ReferenceRequest, ReferenceResponse]):
         reader = DocumentReader(content)
 
         range = loc.range
-        line = range.start.line
         context_range = LSPRange(
-            start=LSPPosition(line=max(0, line - context_lines), character=0),
-            end=LSPPosition(line=line + context_lines + 1, character=0),
+            start=LSPPosition(
+                line=max(0, range.start.line - context_lines), character=0
+            ),
+            end=LSPPosition(line=range.end.line + context_lines + 1, character=0),
         )
-        if not (snippet := reader.read(context_range)):
+        if not (snippet := reader.read(context_range, trim_empty=True)):
             return
 
         symbol: SymbolDetailInfo | None = None

--- a/src/lsap/utils/capability.py
+++ b/src/lsap/utils/capability.py
@@ -7,6 +7,19 @@ from lsap.exception import UnsupportedCapabilityError
 def ensure_capability[C: CapabilityProtocol](
     client: Client, capability: type[C], *, error: str | None = None
 ) -> C:
+    """Ensure that the client supports the specified capability.
+
+    Args:
+        client: The LSP client instance.
+        capability: The capability protocol class to check against.
+        error: Optional custom error message suffix.
+
+    Returns:
+        The client instance cast to the specified capability type.
+
+    Raises:
+        UnsupportedCapabilityError: If the client does not support the capability.
+    """
     if not error:
         error = "This operation cannot be performed."
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -111,3 +111,37 @@ def test_read_dedent():
     assert result is not None
     assert result.exact_content == "pass"
     assert result.content == "2| pass"
+
+
+def test_read_trim_empty():
+    content = "\n\n  \nline one\nline two\n\n\n"
+    reader = DocumentReader(document=content)
+
+    # Read the whole thing but trim empty lines
+    read_range = Range(
+        start=Position(line=0, character=0), end=Position(line=7, character=0)
+    )
+
+    # Without trim
+    result_no_trim = reader.read(read_range, trim_empty=False)
+    assert result_no_trim is not None
+    assert result_no_trim.content.count("\n") == 7
+
+    # With trim
+    result_trim = reader.read(read_range, trim_empty=True)
+    assert result_trim is not None
+    # Lines 4 and 5 (1-based index) are "line one" and "line two"
+    assert result_trim.content == "4| line one\n5| line two\n"
+    assert result_trim.range.start.line == 3
+    assert result_trim.range.end.line == 5
+
+
+def test_read_trim_empty_only_whitespace():
+    content = "\n  \n\t\n"
+    reader = DocumentReader(document=content)
+    read_range = Range(
+        start=Position(line=0, character=0), end=Position(line=3, character=0)
+    )
+
+    result = reader.read(read_range, trim_empty=True)
+    assert result is None


### PR DESCRIPTION
## Summary
- Added `trim_empty` parameter to `DocumentReader.read` to remove leading and trailing whitespace-only lines from code snippets.
- Enabled `trim_empty` in `ReferenceCapability` to provide cleaner context for symbol references.
- Fixed a bug in `ReferenceCapability` context calculation to correctly include the full range of multi-line references.
- Added a docstring to `ensure_capability` utility.
- Added unit tests for the new trimming logic in `DocumentReader`.