### PR TITLE
refactor: Refactor LineScope

### DIFF
--- a/src/lsap/capability/locate.py
+++ b/src/lsap/capability/locate.py
@@ -65,20 +65,15 @@ async def _get_scope_info(
         case None:
             return ScopeInfo(reader.full_range, None)
 
-        case LineScope(line=line):
-            match line:
-                case int():
-                    start, end = line - 1, line - 1
-                case (s, e):
-                    start, end = s - 1, e - 1
-
-            return ScopeInfo(
-                LSPRange(
-                    start=LSPPosition(line=start, character=0),
-                    end=LSPPosition(line=end + 1, character=0),
-                ),
-                None,
+        case LineScope(start_line=start_line, end_line=end_line):
+            start = LSPPosition(line=start_line - 1, character=0)
+            end = (
+                reader.full_range.end
+                if end_line == 0
+                else LSPPosition(line=end_line - 1, character=0)
             )
+
+            return ScopeInfo(LSPRange(start=start, end=end), None)
         case SymbolScope(symbol_path=path):
             symbols = await ensure_capability(
                 client, WithRequestDocumentSymbol

--- a/src/lsap/schema/draft/hierarchy.py
+++ b/src/lsap/schema/draft/hierarchy.py
@@ -129,7 +129,7 @@ class HierarchyRequest(LocateRequest):
     1. Find who calls a function (incoming calls):
        HierarchyRequest(
            hierarchy_type="call",
-           locate=Locate(file_path="src/main.py", scope=LineScope(line=10), find="process_data"),
+           locate=Locate(file_path="src/main.py", scope=LineScope(start_line=10, end_line=11), find="process_data"),
            direction="incoming",
            depth=2
        )
@@ -137,7 +137,7 @@ class HierarchyRequest(LocateRequest):
     2. Find what a function calls (outgoing calls):
        HierarchyRequest(
            hierarchy_type="call",
-           locate=Locate(file_path="src/main.py", scope=LineScope(line=10), find="process_data"),
+           locate=Locate(file_path="src/main.py", scope=LineScope(start_line=10, end_line=11), find="process_data"),
            direction="outgoing",
            depth=2
        )
@@ -145,7 +145,7 @@ class HierarchyRequest(LocateRequest):
     3. Find parent classes (incoming in type hierarchy):
        HierarchyRequest(
            hierarchy_type="type",
-           locate=Locate(file_path="src/models.py", scope=LineScope(line=5), find="UserModel"),
+           locate=Locate(file_path="src/models.py", scope=LineScope(start_line=5, end_line=6), find="UserModel"),
            direction="incoming",
            depth=2
        )
@@ -153,7 +153,7 @@ class HierarchyRequest(LocateRequest):
     4. Find child classes (outgoing in type hierarchy):
        HierarchyRequest(
            hierarchy_type="type",
-           locate=Locate(file_path="src/models.py", scope=LineScope(line=5), find="BaseModel"),
+           locate=Locate(file_path="src/models.py", scope=LineScope(start_line=5, end_line=6), find="BaseModel"),
            direction="outgoing",
            depth=2
        )

--- a/src/lsap/schema/locate.py
+++ b/src/lsap/schema/locate.py
@@ -12,8 +12,7 @@ A concise string syntax is available: `<file_path>:<scope>@<find>`
 ### Scope formats
 
 - `<line>`: Single line number (e.g., `"42"`)
-- `<start>,<end>`: Line range with comma (e.g., `"10,20"`)
-- `<start>-<end>`: Line range with dash (e.g., `"10-20"`)
+- `<start>,<end>`: Line range with comma (e.g., `"10,20"`). Use `0` for `<end>` to mean till EOF (e.g., `"10,0"`)
 - `<symbol_path>`: Symbol path with dots (e.g., `"MyClass.my_method"`)
 
 ### Examples
@@ -28,7 +27,7 @@ A concise string syntax is available: `<file_path>:<scope>@<find>`
 from pathlib import Path
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ._abc import Request, Response
 from .models import Position, Range
@@ -38,8 +37,10 @@ from .types import SymbolPath
 class LineScope(BaseModel):
     """Scope by line range"""
 
-    line: int | tuple[int, int]
-    """Line number or (start, end) range (1-based)"""
+    start_line: int = Field(ge=1, description="Start line number (1-based, inclusive)")
+    end_line: int = Field(
+        description="End line number (1-based, exclusive). When set to 0, means till EOF."
+    )
 
 
 class SymbolScope(BaseModel):

--- a/src/lsap/utils/locate.py
+++ b/src/lsap/utils/locate.py
@@ -60,17 +60,15 @@ def parse_locate_string(locate_str: str) -> Locate:
 
     Scope formats:
         - <line> - Single line number (e.g., "42")
-        - <start>,<end> - Line range with comma (e.g., "10,20")
-        - <start>-<end> - Line range with dash (e.g., "10-20")
+        - <start>,<end> - Line range with comma (e.g., "10,20"). Use 0 for end to mean till EOF (e.g., "10,0")
         - <symbol_path> - Symbol path with dots (e.g., "MyClass.my_method")
 
     Examples:
         - "foo.py:42@return <|>result" - Line 42, find pattern
-        - "foo.py:10,20@if <|>condition" - Line range 10-20, find pattern
+        - "foo.py:10,20@if <|>condition" - Line range 10,20, find pattern
         - "foo.py:MyClass.my_method@self.<|>" - Symbol scope, find pattern
         - "foo.py@self.<|>" - Whole file, find pattern
         - "foo.py:MyClass" - Symbol scope only
-        - "foo.py:10-20" - Line range scope
     """
     # Split by @ first to separate find from file_path:scope
     if "@" in locate_str:
@@ -94,14 +92,14 @@ def parse_locate_string(locate_str: str) -> Locate:
         if "," in scope_str:
             # Comma-separated line range: "10,20"
             start, end = scope_str.split(",", 1)
-            scope = LineScope(line=(int(start), int(end)))
-        elif "-" in scope_str and scope_str.replace("-", "").isdigit():
-            # Dash-separated line range: "10-20"
-            start, end = scope_str.split("-", 1)
-            scope = LineScope(line=(int(start), int(end)))
+            start_val = int(start)
+            end_val = int(end)
+            # 0 means till EOF, otherwise it's 1-based exclusive
+            actual_end = 0 if end_val == 0 else end_val + 1
+            scope = LineScope(start_line=start_val, end_line=actual_end)
         elif scope_str.isdigit():
             # Single line number: "42"
-            scope = LineScope(line=int(scope_str))
+            scope = LineScope(start_line=int(scope_str), end_line=int(scope_str) + 1)
         else:
             # Treat as symbol path
             symbol_path = scope_str.split(".")

--- a/tests/test_definition.py
+++ b/tests/test_definition.py
@@ -132,7 +132,11 @@ async def test_definition():
     capability = DefinitionCapability(client=client)  # type: ignore
 
     req = DefinitionRequest(
-        locate=Locate(file_path=Path("main.py"), scope=LineScope(line=2), find="foo"),
+        locate=Locate(
+            file_path=Path("main.py"),
+            scope=LineScope(start_line=2, end_line=3),
+            find="foo",
+        ),
         mode="definition",
     )
 
@@ -156,7 +160,11 @@ async def test_unsupported_declaration():
     # when a capability is not supported, but the mock now supports everything.
     # This test passes by design - the capability is supported.
     req = DefinitionRequest(
-        locate=Locate(file_path=Path("main.py"), scope=LineScope(line=2), find="foo"),
+        locate=Locate(
+            file_path=Path("main.py"),
+            scope=LineScope(start_line=2, end_line=3),
+            find="foo",
+        ),
         mode="declaration",
     )
 

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -44,7 +44,11 @@ async def test_doc():
     capability = DocCapability(client=client)  # type: ignore
 
     req = DocRequest(
-        locate=Locate(file_path=Path("main.py"), scope=LineScope(line=1), find="foo"),
+        locate=Locate(
+            file_path=Path("main.py"),
+            scope=LineScope(start_line=1, end_line=2),
+            find="foo",
+        ),
     )
 
     resp = await capability(req)
@@ -58,7 +62,11 @@ async def test_doc_not_found():
     capability = DocCapability(client=client)  # type: ignore
 
     req = DocRequest(
-        locate=Locate(file_path=Path("main.py"), scope=LineScope(line=1), find="bar"),
+        locate=Locate(
+            file_path=Path("main.py"),
+            scope=LineScope(start_line=1, end_line=2),
+            find="bar",
+        ),
     )
 
     resp = await capability(req)

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -20,7 +20,7 @@ async def test_locate_text_ambiguous():
     req = LocateRequest(
         locate=Locate(
             file_path=Path("test.py"),
-            scope=LineScope(line=(1, 2)),
+            scope=LineScope(start_line=1, end_line=3),
             find="abc",
         )
     )
@@ -39,7 +39,7 @@ async def test_locate_text_single_match():
     req = LocateRequest(
         locate=Locate(
             file_path=Path("test.py"),
-            scope=LineScope(line=(1, 2)),
+            scope=LineScope(start_line=1, end_line=3),
             find="def",
         )
     )

--- a/tests/test_locate_integration.py
+++ b/tests/test_locate_integration.py
@@ -93,7 +93,7 @@ class TestIntegration:
 
     def test_line_range_scope(self):
         """Test line range scope."""
-        locate = parse_locate_string("test.py:10-20@if <|>condition")
+        locate = parse_locate_string("test.py:10,20@if <|>condition")
         assert locate.file_path == Path("test.py")
         assert locate.scope is not None
         assert locate.find == "if <|>condition"

--- a/tests/test_locate_markers.py
+++ b/tests/test_locate_markers.py
@@ -121,15 +121,17 @@ class TestParseLocateString:
         locate = parse_locate_string("foo.py:42@return <|>result")
         assert locate.file_path == Path("foo.py")
         assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == 42
+        assert locate.scope.start_line == 42
+        assert locate.scope.end_line == 43
         assert locate.find == "return <|>result"
 
     def test_parse_file_line_range_and_find(self):
         """Test parsing with line range scope and find pattern."""
-        locate = parse_locate_string("foo.py:10-20@if <|>condition")
+        locate = parse_locate_string("foo.py:10,20@if <|>condition")
         assert locate.file_path == Path("foo.py")
         assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == (10, 20)
+        assert locate.scope.start_line == 10
+        assert locate.scope.end_line == 21
         assert locate.find == "if <|>condition"
 
     def test_parse_file_symbol_scope_and_find(self):
@@ -153,7 +155,8 @@ class TestParseLocateString:
         locate = parse_locate_string("foo.py:42")
         assert locate.file_path == Path("foo.py")
         assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == 42
+        assert locate.scope.start_line == 42
+        assert locate.scope.end_line == 43
         assert locate.find is None
 
     def test_parse_nested_path(self):
@@ -182,7 +185,8 @@ class TestParseLocateString:
         locate = parse_locate_string("foo.py:42@return <|>result")
         assert locate.file_path == Path("foo.py")
         assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == 42
+        assert locate.scope.start_line == 42
+        assert locate.scope.end_line == 43
         assert locate.find == "return <|>result"
 
     def test_parse_line_range_with_comma(self):
@@ -190,23 +194,17 @@ class TestParseLocateString:
         locate = parse_locate_string("foo.py:10,20@if <|>condition")
         assert locate.file_path == Path("foo.py")
         assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == (10, 20)
+        assert locate.scope.start_line == 10
+        assert locate.scope.end_line == 21
         assert locate.find == "if <|>condition"
-
-    def test_parse_line_range_with_dash_no_prefix(self):
-        """Test parsing with line range using dash without L prefix."""
-        locate = parse_locate_string("foo.py:10-20@while <|>loop")
-        assert locate.file_path == Path("foo.py")
-        assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == (10, 20)
-        assert locate.find == "while <|>loop"
 
     def test_parse_line_number_only_no_find(self):
         """Test parsing with line number only, no find pattern."""
         locate = parse_locate_string("foo.py:123")
         assert locate.file_path == Path("foo.py")
         assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == 123
+        assert locate.scope.start_line == 123
+        assert locate.scope.end_line == 124
         assert locate.find is None
 
     def test_parse_line_range_comma_no_find(self):
@@ -214,5 +212,15 @@ class TestParseLocateString:
         locate = parse_locate_string("foo.py:12,14")
         assert locate.file_path == Path("foo.py")
         assert isinstance(locate.scope, LineScope)
-        assert locate.scope.line == (12, 14)
+        assert locate.scope.start_line == 12
+        assert locate.scope.end_line == 15
+        assert locate.find is None
+
+    def test_parse_line_range_till_eof(self):
+        """Test parsing with line range till EOF (end_line=0)."""
+        locate = parse_locate_string("foo.py:10,0")
+        assert locate.file_path == Path("foo.py")
+        assert isinstance(locate.scope, LineScope)
+        assert locate.scope.start_line == 10
+        assert locate.scope.end_line == 0
         assert locate.find is None

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -147,7 +147,11 @@ async def test_reference():
     capability = ReferenceCapability(client=client)  # type: ignore
 
     req = ReferenceRequest(
-        locate=Locate(file_path=Path("test.py"), scope=LineScope(line=2), find="foo")
+        locate=Locate(
+            file_path=Path("test.py"),
+            scope=LineScope(start_line=2, end_line=3),
+            find="foo",
+        )
     )
 
     resp = await capability(req)
@@ -166,7 +170,11 @@ async def test_reference_pagination():
 
     # First page
     req1 = ReferenceRequest(
-        locate=Locate(file_path=Path("test.py"), scope=LineScope(line=2), find="foo"),
+        locate=Locate(
+            file_path=Path("test.py"),
+            scope=LineScope(start_line=2, end_line=3),
+            find="foo",
+        ),
         max_items=1,
     )
     resp1 = await capability(req1)
@@ -177,7 +185,11 @@ async def test_reference_pagination():
 
     # Second page
     req2 = ReferenceRequest(
-        locate=Locate(file_path=Path("test.py"), scope=LineScope(line=2), find="foo"),
+        locate=Locate(
+            file_path=Path("test.py"),
+            scope=LineScope(start_line=2, end_line=3),
+            find="foo",
+        ),
         pagination_id=resp1.pagination_id,
         start_index=1,
         max_items=1,
@@ -199,7 +211,11 @@ async def test_unsupported_implementation():
     # when a capability is not supported, but the mock now supports everything.
     # This test passes by design - the capability is supported.
     req = ReferenceRequest(
-        locate=Locate(file_path=Path("test.py"), scope=LineScope(line=2), find="foo"),
+        locate=Locate(
+            file_path=Path("test.py"),
+            scope=LineScope(start_line=2, end_line=3),
+            find="foo",
+        ),
         mode="implementations",
     )
 

--- a/tests/test_symbol.py
+++ b/tests/test_symbol.py
@@ -135,7 +135,7 @@ async def test_symbol_from_text():
     req = SymbolRequest(
         locate=Locate(
             file_path=Path("test.py"),
-            scope=LineScope(line=2),
+            scope=LineScope(start_line=2, end_line=3),
             find="foo",
         )
     )

--- a/tests/test_unified_hierarchy.py
+++ b/tests/test_unified_hierarchy.py
@@ -98,7 +98,7 @@ def test_unified_hierarchy_request_call():
         hierarchy_type="call",
         locate=Locate(
             file_path=Path("test.py"),
-            scope=LineScope(line=10),
+            scope=LineScope(start_line=10, end_line=11),
             find="my_function",
         ),
         direction="both",
@@ -119,7 +119,7 @@ def test_unified_hierarchy_request_type():
         hierarchy_type="type",
         locate=Locate(
             file_path=Path("test.py"),
-            scope=LineScope(line=5),
+            scope=LineScope(start_line=5, end_line=6),
             find="MyClass",
         ),
         direction="outgoing",


### PR DESCRIPTION
## Summary
- Refactored `LineScope` in `src/lsap/schema/locate.py` from `line: int | tuple[int, int]` to explicit `start_line` and `end_line` fields.
- Removed support for dash-separated line ranges (e.g., `10-20`) in `parse_locate_string`, standardizing on comma-separated ranges.
- Added documentation and support for `end_line=0` to represent "until EOF" in both schema and string parsing.
- Updated all internal callers and tests to reflect these changes.