### PR TITLE
feat: redesign outline to filter local variables and support top-level expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ wheels/
 uv.lock
 
 references/
+test.py

--- a/src/lsap/schema/outline.py
+++ b/src/lsap/schema/outline.py
@@ -43,9 +43,17 @@ class OutlineRequest(Request):
 
     Use this to understand the structure of a file (classes, methods, functions)
     and quickly navigate its contents.
+
+    Note: By default (top=False), this API returns structural symbols only
+    (classes, methods, top-level functions/variables), excluding symbols
+    defined inside functions or methods (like local variables or nested
+    functions) to reduce noise. When top=True, only first-level symbols
+    are returned.
     """
 
     file_path: Path
+    top: bool = False
+    """If true, return only top-level symbols (expanding Module containers to show their direct children, and excluding nested members of classes and functions)."""
 
 
 markdown_template: Final = """

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -120,3 +120,172 @@ async def test_outline():
 
     assert resp.items[1].name == "foo"
     assert len(resp.items[1].path) == 2
+
+
+@pytest.mark.asyncio
+async def test_outline_top():
+    client = MockOutlineClient()
+    capability = OutlineCapability(client=client)  # type: ignore
+
+    req = OutlineRequest(file_path=Path("test.py"), top=True)
+
+    resp = await capability(req)
+    assert resp is not None
+    assert len(resp.items) == 1
+
+    assert resp.items[0].name == "A"
+    assert len(resp.items[0].path) == 1
+
+
+@pytest.mark.asyncio
+async def test_outline_top_expansion():
+    class MockModuleClient(MockOutlineClient):
+        async def request_document_symbol_list(self, file_path) -> list[DocumentSymbol]:
+            foo_symbol = DocumentSymbol(
+                name="foo",
+                kind=SymbolKind.Function,
+                range=LSPRange(
+                    start=LSPPosition(line=1, character=0),
+                    end=LSPPosition(line=1, character=10),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=1, character=4),
+                    end=LSPPosition(line=1, character=7),
+                ),
+            )
+            module_symbol = DocumentSymbol(
+                name="mymodule",
+                kind=SymbolKind.Module,
+                range=LSPRange(
+                    start=LSPPosition(line=0, character=0),
+                    end=LSPPosition(line=2, character=0),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=0, character=0),
+                    end=LSPPosition(line=0, character=0),
+                ),
+                children=[foo_symbol],
+            )
+            return [module_symbol]
+
+    client = MockModuleClient()
+    capability = OutlineCapability(client=client)  # type: ignore
+
+    req = OutlineRequest(file_path=Path("test.py"), top=True)
+
+    resp = await capability(req)
+    assert resp is not None
+    assert len(resp.items) == 1
+    assert resp.items[0].name == "foo"
+    assert resp.items[0].path == ["mymodule", "foo"]
+
+
+@pytest.mark.asyncio
+async def test_outline_filtering():
+    class MockFilteringClient(MockOutlineClient):
+        async def request_document_symbol_list(self, file_path) -> list[DocumentSymbol]:
+            inner_var = DocumentSymbol(
+                name="x",
+                kind=SymbolKind.Variable,
+                range=LSPRange(
+                    start=LSPPosition(line=2, character=8),
+                    end=LSPPosition(line=2, character=9),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=2, character=8),
+                    end=LSPPosition(line=2, character=9),
+                ),
+            )
+            inner_func = DocumentSymbol(
+                name="inner",
+                kind=SymbolKind.Function,
+                range=LSPRange(
+                    start=LSPPosition(line=3, character=8),
+                    end=LSPPosition(line=4, character=8),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=3, character=12),
+                    end=LSPPosition(line=3, character=17),
+                ),
+            )
+            foo_symbol = DocumentSymbol(
+                name="foo",
+                kind=SymbolKind.Function,
+                range=LSPRange(
+                    start=LSPPosition(line=1, character=0),
+                    end=LSPPosition(line=5, character=0),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=1, character=4),
+                    end=LSPPosition(line=1, character=7),
+                ),
+                children=[inner_var, inner_func],
+            )
+            return [foo_symbol]
+
+    client = MockFilteringClient()
+    capability = OutlineCapability(client=client)  # type: ignore
+
+    req = OutlineRequest(file_path=Path("test.py"))
+
+    resp = await capability(req)
+    assert resp is not None
+    # Should only contain 'foo', not 'x' or 'inner'
+    assert len(resp.items) == 1
+    assert resp.items[0].name == "foo"
+
+
+@pytest.mark.asyncio
+async def test_outline_nested_modules():
+    class MockNestedModuleClient(MockOutlineClient):
+        async def request_document_symbol_list(self, file_path) -> list[DocumentSymbol]:
+            func_c = DocumentSymbol(
+                name="C",
+                kind=SymbolKind.Function,
+                range=LSPRange(
+                    start=LSPPosition(line=2, character=0),
+                    end=LSPPosition(line=2, character=10),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=2, character=4),
+                    end=LSPPosition(line=2, character=5),
+                ),
+            )
+            mod_b = DocumentSymbol(
+                name="B",
+                kind=SymbolKind.Module,
+                range=LSPRange(
+                    start=LSPPosition(line=1, character=0),
+                    end=LSPPosition(line=3, character=0),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=1, character=0),
+                    end=LSPPosition(line=1, character=0),
+                ),
+                children=[func_c],
+            )
+            mod_a = DocumentSymbol(
+                name="A",
+                kind=SymbolKind.Module,
+                range=LSPRange(
+                    start=LSPPosition(line=0, character=0),
+                    end=LSPPosition(line=4, character=0),
+                ),
+                selection_range=LSPRange(
+                    start=LSPPosition(line=0, character=0),
+                    end=LSPPosition(line=0, character=0),
+                ),
+                children=[mod_b],
+            )
+            return [mod_a]
+
+    client = MockNestedModuleClient()
+    capability = OutlineCapability(client=client)  # type: ignore
+
+    req = OutlineRequest(file_path=Path("test.py"), top=True)
+
+    resp = await capability(req)
+    assert resp is not None
+    assert len(resp.items) == 1
+    assert resp.items[0].name == "C"
+    assert resp.items[0].path == ["A", "B", "C"]


### PR DESCRIPTION
## Summary
- **Symbol Filtering**: Redesigned `OutlineCapability` to exclude implementation details (local variables, nested functions/classes) inside functions, methods, and constructors.
- **Top-level Expansion**: Added a `top` parameter to `OutlineRequest` and implemented logic to expand `Module` symbols to return their first-level structural children.
- **Documentation**: Updated `OutlineRequest` docstrings to clarify the new structural-only focus of the Outline API.
- **Testing**: Added new test cases in `tests/test_outline.py` to verify top-level expansion and filtering behavior.

## Why
The Outline API is intended to provide a high-level overview of a file's structure. Local variables and nested definitions within functions often introduce noise that makes it harder for Agents to quickly understand the overall layout.