### PR TITLE
Fix: remove redundant markdown escapes in hover content

### DIFF
--- a/src/lsap/utils/markdown.py
+++ b/src/lsap/utils/markdown.py
@@ -1,12 +1,13 @@
 import html
+import re
 
 
 def clean_hover_content(content: str) -> str:
     r"""
     Clean up hover content by unescaping HTML entities and removing unnecessary
-    Markdown escapes (like \_) to ensure it is pure Markdown.
+    Markdown escapes to ensure it is pure Markdown.
     """
     unescaped = html.unescape(content)
-    # Remove unnecessary backslash escapes for underscores, as they are often
-    # over-escaped by some language servers but usually not needed in code symbols.
-    return unescaped.replace("\\_", "_")
+    # Remove unnecessary backslash escapes for punctuation characters that are
+    # often over-escaped by some language servers.
+    return re.sub(r"\\([!\"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~])", r"\1", unescaped)

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,26 @@
+from lsap.utils.markdown import clean_hover_content
+
+
+def test_clean_hover_content_basic():
+    assert clean_hover_content("foo") == "foo"
+    assert clean_hover_content("foo\\_bar") == "foo_bar"
+    assert clean_hover_content("foo\\\\bar") == "foo\\bar"
+
+
+def test_clean_hover_content_html_unescape():
+    assert clean_hover_content("foo &amp; bar") == "foo & bar"
+    assert clean_hover_content("foo &lt; bar") == "foo < bar"
+
+
+def test_clean_hover_content_multiple_escapes():
+    # Test common over-escaped characters in Markdown
+    content = r"func\(arg1, arg2\) \{ return \*ptr; \}"
+    expected = "func(arg1, arg2) { return *ptr; }"
+    assert clean_hover_content(content) == expected
+
+
+def test_clean_hover_content_all_punctuation():
+    # All ASCII punctuation characters: !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
+    escaped = r"\!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~"
+    expected = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+    assert clean_hover_content(escaped) == expected


### PR DESCRIPTION
## Summary
- Fixed redundant markdown escapes in hover content by unescaping all standard ASCII punctuation characters.
- Added comprehensive tests for markdown content cleaning.