### PR TITLE
fix: add pagination_id and standardized pagination info to templates

### DIFF
--- a/src/lsap/capability/search.py
+++ b/src/lsap/capability/search.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol, override, runtime_checkable
+from typing import override
 
 from attrs import Factory, define
 from lsp_client.capability.request import WithRequestWorkspaceSymbol
+from lsp_client.capability.request.workspace_symbol import (
+    WithRequestWorkspaceSymbolResolve,
+)
 from lsprotocol.types import Location, WorkspaceSymbol
 
 from lsap.schema.models import SymbolKind
@@ -14,13 +17,6 @@ from lsap.utils.capability import ensure_capability
 from lsap.utils.pagination import paginate
 
 from .abc import Capability
-
-
-@runtime_checkable
-class CanResolveWorkspaceSymbol(Protocol):
-    async def resolve_workspace_symbols(
-        self, symbols: Sequence[WorkspaceSymbol]
-    ) -> Sequence[WorkspaceSymbol]: ...
 
 
 @define
@@ -48,7 +44,7 @@ class SearchCapability(Capability[SearchRequest, SearchResponse]):
 
         # Resolve items in the current page
         symbols = result.items
-        if isinstance(self.client, CanResolveWorkspaceSymbol):
+        if isinstance(self.client, WithRequestWorkspaceSymbolResolve):
             symbols = await self.client.resolve_workspace_symbols(symbols)
 
         items = self._to_search_items(symbols)

--- a/src/lsap/schema/draft/completion.py
+++ b/src/lsap/schema/draft/completion.py
@@ -61,6 +61,9 @@ class CompletionRequest(LocateRequest, PaginatedRequest):
 
 markdown_template: Final = """
 # Code Completion
+{% if total != nil -%}
+Total suggestions: {{ total }} | Showing: {{ items.size }}{% if max_items != nil %} (Offset: {{ start_index }}, Limit: {{ max_items }}){% endif %}
+{%- endif %}
 
 {% if items.size == 0 -%}
 No completion suggestions found.
@@ -86,12 +89,14 @@ No completion suggestions found.
 {% if has_more -%}
 ---
 > [!TIP]
+> More suggestions available.
 {%- if pagination_id != nil %}
-> Use `pagination_id="{{ pagination_id }}"` to fetch more suggestions.
+> Use `pagination_id="{{ pagination_id }}"` to fetch the next page.
 {%- else %}
-> More results available. Use `start_index` to fetch more.
+> To see more, specify a `max_items` and use: `start_index={% assign step = max_items | default: items.size %}{{ start_index | plus: step }}`
 {%- endif %}
 {%- endif %}
+
 
 ---
 > [!TIP]

--- a/src/lsap/schema/search.py
+++ b/src/lsap/schema/search.py
@@ -86,7 +86,7 @@ class SearchRequest(PaginatedRequest):
 markdown_template: Final = """
 # Search: `{{ request.query }}`
 {% if total != nil -%}
-Found {{ total }} results{% if max_items != nil %} (showing {{ items.size }}){% endif %}
+Found {{ total }} results | Showing: {{ items.size }}{% if max_items != nil %} (Offset: {{ start_index }}, Limit: {{ max_items }}){% endif %}
 {%- endif %}
 
 {% if items.size == 0 -%}
@@ -97,7 +97,14 @@ No matches found.
 {%- endfor %}
 
 {% if has_more -%}
-> More results available. Use `start_index={{ start_index | plus: items.size }}` for next page.
+---
+> [!TIP]
+> More results available.
+{%- if pagination_id != nil %}
+> Use `pagination_id="{{ pagination_id }}"` to fetch the next page.
+{%- else %}
+> To see more, specify a `max_items` and use: `start_index={% assign step = max_items | default: items.size %}{{ start_index | plus: step }}`
+{%- endif %}
 {%- endif %}
 {%- endif %}
 """


### PR DESCRIPTION
## Summary
- Added `pagination_id` support to `search` and `completion` templates.
- Standardized pagination result summary to include total, offset, and limit.
- Updated pagination instructions to consistently provide `pagination_id` (if present) or fallback `start_index` formula.
- Refactored `SearchCapability` to use `WithRequestWorkspaceSymbolResolve` instead of local protocol.