### PR TITLE
doc: add API design skill mandate to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@
 
 - Path Handling: `client.from_uri()` returns relative paths by default. Use `relative=False` explicitly when absolute paths are required (e.g., for path comparisons in exclusion sets).
 
+## API Design
+
+- **Skill**: MUST use `lsap-api-design` skill first before designing new APIs
+
 ## Testing
 
 - Run `uv sync --upgrade` before testing and fixing type errors


### PR DESCRIPTION
## Summary
- Added a new mandate to `AGENTS.md` requiring the use of `lsap-api-design` skill before designing new APIs.
- This ensures consistency and adherence to established design patterns in the codebase.